### PR TITLE
Retry code added for HTTP responses 500/502/504

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+*.dll
+*.pdb
+*.exe
+*.cache


### PR DESCRIPTION
We are seeing intermittent issues of 500/502/504 which seem to self-resolve within a minute. So added exception handling and retry for these error codes.